### PR TITLE
Tidy CLI logging around config prompts

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const readline = require('readline');
 const stream = require('stream');
 const yaml = require('yaml');
 const fs = require('fs');
+const path = require('path');
 const simpleLogger = require('simple-node-logger');
 
 const parser = new argparse.ArgumentParser({
@@ -21,12 +22,28 @@ parser.add_argument('config', { help: 'config filename to use', nargs: '?'});
 let args = parser.parse_args();
 
 if (args) {
-    const logger = simpleLogger.createSimpleLogger();
+    const logFilePath = path.resolve(process.cwd(), 'log.txt');
+    const logger = simpleLogger.createSimpleFileLogger(logFilePath);
+    const bindConsoleEcho = (level, emitter) => {
+        const original = logger[level].bind(logger);
+        logger[level] = (...messages) => {
+            original(...messages);
+            emitter(...messages);
+        };
+    };
+
+    bindConsoleEcho('error', (...messages) => console.error(...messages));
+    bindConsoleEcho('warn', (...messages) => console.warn(...messages));
+
+    logger.info(`Logging initialized. Writing output to ${logFilePath}`);
+    console.log(`Logging initialized. Writing output to ${logFilePath}`);
+
     if (args.debug)
         logger.setLevel('trace');
 
     if (args.version) {
         logger.info('Version: ' + package.version);
+        console.log('Version: ' + package.version);
         return;
     }
 
@@ -51,16 +68,34 @@ if (args) {
                 mutableStdout.muted = true;
                 process.stdout.write('Onvif Password: ');
                 rl.question('', (password) => {
+                    logger.info('Generating config ...');
                     console.log('Generating config ...');
-                    configBuilder.createConfig(hostname, username, password).then((config) => {
-                        if (config) {
-                            console.log('# ==================== CONFIG START ====================');
-                            console.log(yaml.stringify(config));
-                            console.log('# ===================== CONFIG END =====================');
-                        } else
-                        console.log('Failed to create config!');
-                    });
-                    rl.close();
+                    const finalize = () => {
+                        mutableStdout.muted = false;
+                        rl.close();
+                    };
+
+                    configBuilder.createConfig(hostname, username, password, logger)
+                        .then((config) => {
+                            if (config) {
+                                logger.info('Config created successfully. Outputting generated configuration.');
+                                console.log('# ==================== CONFIG START ====================');
+                                console.log(yaml.stringify(config));
+                                console.log('# ===================== CONFIG END =====================');
+                            } else {
+                                logger.error('Config builder returned no configuration object.');
+                                console.log('Failed to create config! Check log.txt for details.');
+                            }
+                            finalize();
+                        })
+                        .catch((error) => {
+                            const message = error && error.message ? error.message : error;
+                            logger.error(`Failed to create config: ${message}`);
+                            if (error && error.stack)
+                                logger.error(error.stack);
+                            console.log('Failed to create config! Check log.txt for details.');
+                            finalize();
+                        });
                 });
             });
         });


### PR DESCRIPTION
## Summary
- switch the CLI to a file-only logger and mirror warnings/errors to stderr to avoid polluting interactive prompts
- manually echo informational status messages so the create-config workflow keeps users informed without clobbering the prompts

## Testing
- printf 'host\nuser\npass\n' | node main.js --create-config
- node main.js --version

------
https://chatgpt.com/codex/tasks/task_e_68d184e25810832396ba66780a3fdabb